### PR TITLE
Allow use of Path Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can, of course, pass some custom values to make it more prone to your usage.
 ENV TZ "UTC"
 ENV HOSTS "community:host[:version[:port]]"
 ENV WEBDIR "/mrtg/html"
+ENV PATHPREFIX "/"
 ```
 
 The variable `TZ` will configure the timezone used by the OS and MRTG to show dates and times.
@@ -46,6 +47,10 @@ The variable `HOSTS` is where you may set the hosts that MRTG will monitor.  The
   * **_host_**: is the IP address or hostname (if Docker can resolve it)
   * **_version_**: can be `1` or `2` for SNMP **1** or **2c**.  If left empty it will assume **2c**.
   * **_port_**: can be any custom port.  There is one point of attention, if the port is needed then the version must be set.
+
+The variable `PATHPREFIX` (default: /) is the path passed to indexmaker to prefix URLs to rrdviewer or any images.
+ The format must NOT include a trailing slash.  For example, "/mrtg"
+ Used with a reverse proxy, this allows mrtg to exist at a subpath, rather than the root.
 
 ## Persistency
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can, of course, pass some custom values to make it more prone to your usage.
 ENV TZ "UTC"
 ENV HOSTS "community:host[:version[:port]]"
 ENV WEBDIR "/mrtg/html"
-ENV PATHPREFIX "/"
+ENV PATHPREFIX ""
 ```
 
 The variable `TZ` will configure the timezone used by the OS and MRTG to show dates and times.
@@ -48,7 +48,7 @@ The variable `HOSTS` is where you may set the hosts that MRTG will monitor.  The
   * **_version_**: can be `1` or `2` for SNMP **1** or **2c**.  If left empty it will assume **2c**.
   * **_port_**: can be any custom port.  There is one point of attention, if the port is needed then the version must be set.
 
-The variable `PATHPREFIX` (default: /) is the path passed to indexmaker to prefix URLs to rrdviewer or any images.
+The variable `PATHPREFIX` (default: empty string) is the path passed to indexmaker to prefix URLs to rrdviewer or any images.
  The format must NOT include a trailing slash.  For example, "/mrtg"
  Used with a reverse proxy, this allows mrtg to exist at a subpath, rather than the root.
 

--- a/files/mrtg.sh
+++ b/files/mrtg.sh
@@ -51,7 +51,7 @@ sleep 2
 env LANG=C /usr/bin/mrtg ${MRTGCFG}
 sleep 2
 env LANG=C /usr/bin/mrtg ${MRTGCFG}
-/usr/bin/indexmaker --columns=1 ${MRTGCFG} > ${WEBDIR}/index.html
+/usr/bin/indexmaker --columns=1 ${MRTGCFG} -rrdviewer=${PATHPREFIX}/cgi-bin/14all.cgi --icondir=/ --prefix=${PATHPREFIX}/ >> ${WEBDIR}/index.html
 chown -R lighttpd:lighttpd ${WEBDIR}
 
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf -D &

--- a/files/mrtg.sh
+++ b/files/mrtg.sh
@@ -3,6 +3,7 @@
 MRTGDIR=${MRTGDIR:-"/etc/mrtg"}
 WEBDIR=${WEBDIR:-"/mrtg/html"}
 MRTGCFG=${MRTGDIR}/mrtg.cfg
+PATHPREFIX=${PATHPREFIX:-"/"}
 
 [[ ! -d "${MRTGDIR}" ]] && mkdir -p ${MRTGDIR}
 [[ ! -d "${WEBDIR}" ]] && mkdir -p ${WEBDIR}

--- a/files/mrtg.sh
+++ b/files/mrtg.sh
@@ -3,7 +3,7 @@
 MRTGDIR=${MRTGDIR:-"/etc/mrtg"}
 WEBDIR=${WEBDIR:-"/mrtg/html"}
 MRTGCFG=${MRTGDIR}/mrtg.cfg
-PATHPREFIX=${PATHPREFIX:-"/"}
+PATHPREFIX=${PATHPREFIX:-""}
 
 [[ ! -d "${MRTGDIR}" ]] && mkdir -p ${MRTGDIR}
 [[ ! -d "${WEBDIR}" ]] && mkdir -p ${WEBDIR}


### PR DESCRIPTION
Allow use of path prefix by prefixing index pages appropriately.  Changes are minimal and self-explanatory.

For example https://host.domain.com/mrtg/ could be achieved with PATHPREFIX=/mrtg

Note that the reverse proxy still needs to strip "/mrtg" and pass the request to "/" but this ensures that the links will work rather than showing broken graphs.