### PR TITLE
Add /etc/localtime to docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ services:
     volumes:
       - "./conf.d:/etc/mrtg/conf.d"
       - "./html:/mrtg/html"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/etc/timezone:/etc/timezone:ro"
     environment:
         TZ: "Brazil/East"
         HOSTS: "public:192.168.0.123"


### PR DESCRIPTION
The timezone with just setting TZ appears to be off and displaying UTC rather than the correct timezone.
Mating in /etc/localtime and /etc/timezone fixes that.