### PR TITLE
Fix missing icon images when using PathPrefix

### DIFF
--- a/files/14all.cgi
+++ b/files/14all.cgi
@@ -110,13 +110,13 @@ my $footer_template = <<"EOT";
   <TR>
     <TD WIDTH=63><A ALT="MRTG"
     HREF="http://ee-staff.ethz.ch/~oetiker/webtools/mrtg/mrtg.html"><IMG
-    BORDER=0 SRC="/mrtg-l.png"></A></TD>
+    BORDER=0 SRC="##ICONDIR##/mrtg-l.png"></A></TD>
     <TD WIDTH=25><A ALT=""
     HREF="http://ee-staff.ethz.ch/~oetiker/webtools/mrtg/mrtg.html"><IMG
-    BORDER=0 SRC="/mrtg-m.png"></A></TD>
+    BORDER=0 SRC="##ICONDIR##/mrtg-m.png"></A></TD>
     <TD WIDTH=388><A ALT=""
     HREF="http://ee-staff.ethz.ch/~oetiker/webtools/mrtg/mrtg.html"><IMG
-    BORDER=0 SRC="/mrtg-r.png"></A></TD>
+    BORDER=0 SRC="##ICONDIR##/mrtg-r.png"></A></TD>
   </TR>
 </TABLE>
 <TABLE BORDER=0 CELLSPACING=0 CELLPADDING=0>

--- a/files/mrtg.sh
+++ b/files/mrtg.sh
@@ -11,6 +11,12 @@ groupmod -g ${GROUPID} lighttpd
 [[ ! -d "${MRTGDIR}" ]] && mkdir -p ${MRTGDIR}
 [[ ! -d "${WEBDIR}" ]] && mkdir -p ${WEBDIR}
 
+if [ ! -z ${PATHPREFIX} ]; then
+    echo "IconDir: ${PATHPREFIX}" > ${MRTGDIR}/conf.d/001-IconDir.cfg
+else
+    echo "IconDir: /" > ${MRTGDIR}/conf.d/001-IconDir.cfg
+fi
+
 if [ -n "${HOSTS}" ]; then
     hosts=$(echo ${HOSTS} | tr '[,;]' ' ')
     for asset in ${hosts}; do
@@ -62,7 +68,7 @@ if [ $REGENERATEHTML == "yes" ]; then
   if [ -e "${WEBDIR}/index.html" ]; then
      mv -f "${WEBDIR}/index.html" "${WEBDIR}/index.old"
   fi
-  /usr/bin/indexmaker --columns=1 ${MRTGCFG} -rrdviewer=${PATHPREFIX}/cgi-bin/14all.cgi --icondir=/ --prefix=${PATHPREFIX}/ $INDEXMAKEROPTIONS > ${WEBDIR}/index.html
+  /usr/bin/indexmaker --columns=1 ${MRTGCFG} --rrdviewer=${PATHPREFIX}/cgi-bin/14all.cgi --prefix=${PATHPREFIX}/ $INDEXMAKEROPTIONS > ${WEBDIR}/index.html
 fi
 
 


### PR DESCRIPTION
Currently the icon images show as missing images if one is using a pathprefix, as (1) the ##IconDir## placeholder has been removed from 14all.cgi and (2) the --IconDir is hardcoded as a parameter to IndexMaker.  As such, it will always look for /mrtg-l.png in the root folder rather than the PathPrefix folder.

Both tools pull IconDir from the mrtg.cfg.  Based on the PathPrefix environment, set IconDir in an included cfg file to the PathPrefix.

Tested both with and without a PathPrefix and the icons no longer show broken images.